### PR TITLE
Sub-conditions issue with ifs

### DIFF
--- a/unitvelo/eval_utils.py
+++ b/unitvelo/eval_utils.py
@@ -79,12 +79,13 @@ def cross_boundary_correctness(
     scores = {}
     all_scores = {}
     
-    x_emb = adata.obsm[x_emb]
     if x_emb == "X_umap":
         v_emb = adata.obsm['{}_umap'.format(k_velocity)]
     else:
         v_emb = adata.obsm[[key for key in adata.obsm if key.startswith(k_velocity)][0]]
         
+    x_emb = adata.obsm[x_emb]
+    
     for u, v in cluster_edges:
         sel = adata.obs[k_cluster] == u
         nbs = adata.uns['neighbors']['indices'][sel] # [n * 30]

--- a/unitvelo/model.py
+++ b/unitvelo/model.py
@@ -296,8 +296,8 @@ class Recover_Paras(Model_Utils):
             if (iter > self.agenes_thres) & \
                 (iter == self.config.MAX_ITER - 1 or \
                 tf.math.reduce_all(stop_cond) == True or \
-                min(self.se[self.agenes_thres + 1:]) * 1.1 < self.se[-1] 
-                    if (iter > self.agenes_thres + 1) else False):
+                (min(self.se[self.agenes_thres + 1:]) * 1.1 < self.se[-1] 
+                    if (iter > self.agenes_thres + 1) else False)):
 
                 if (iter > int(0.9 * self.config.MAX_ITER)) & self.config.REG_LOSS & \
                     (min(self.se[self.agenes_thres:]) * 1.1 >= self.se[-1]):


### PR DESCRIPTION
```
if (iter > self.agenes_thres) & \
    (iter == self.config.MAX_ITER - 1 or \
    tf.math.reduce_all(stop_cond) == True or \
    min(self.se[self.agenes_thres + 1:]) * 1.1 < self.se[-1] 
        if (iter > self.agenes_thres + 1) else False):
```

this whole block will return always false` if (iter > self.agenes_thres + 1)` is False.

It is either a missing parenthesis 
```
(min(self.se[self.agenes_thres + 1:]) * 1.1 < self.se[-1] 
        if (iter > self.agenes_thres + 1) else False))
```

meaning that the in-line if is evaluated for the 3rd subcondition.

Otherwise if this was intentional it should be written as: 

```
if (iter > self.agenes_thres+1) & \
    (iter == self.config.MAX_ITER - 1 or \
    tf.math.reduce_all(stop_cond) == True or \
    min(self.se[self.agenes_thres + 1:]) * 1.1 < self.se[-1] ):
```

with no need to do two ifs